### PR TITLE
feat: add support of gitlab groups as gitlab source

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | Sponsoring WG | [Eventing](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#eventing)               |
 
 The Knative GitLab Source registers for events of the specified types on the
-specified GitLab organization or repository, and brings those events into
+specified GitLab group or project, and brings those events into
 Knative. The GiLabSource fires a new event for selected GitLab event types.
 
 ---

--- a/pkg/apis/sources/v1alpha1/gitlabsource_types.go
+++ b/pkg/apis/sources/v1alpha1/gitlabsource_types.go
@@ -48,8 +48,15 @@ type GitLabSourceSpec struct {
 	// to receive events from.
 	// Examples:
 	//   https://gitlab.com/gitlab-org/gitlab-foss
-	// +kubebuilder:validation:MinLength=1
-	ProjectURL string `json:"projectUrl"`
+	// +optional
+	ProjectURL string `json:"projectUrl,omitempty"`
+
+	// GroupURL is the url of the GitLab group for which we are interested
+	// to receive events from.
+	// Examples:
+	//   https://gitlab.com/gitlab-org/gitlab-foss
+	// +optional
+	GroupURL string `json:"groupUrl,omitempty"`
 
 	// List of webhooks to enable on the selected GitLab project.
 	// Those correspond to the attributes enumerated at

--- a/pkg/client/gitlab/webhook_client_test.go
+++ b/pkg/client/gitlab/webhook_client_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/client/gitlab/webhook_client_test.go
+++ b/pkg/client/gitlab/webhook_client_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gitlab
 
 import (

--- a/pkg/client/gitlab/webhook_client_test.go
+++ b/pkg/client/gitlab/webhook_client_test.go
@@ -40,10 +40,10 @@ func TestWebhookClientGetterReturnsExpectedWebhookClient(t *testing.T) {
 		"GitLab GroupURL": {
 			Spec: &v1alpha1.GitLabSource{
 				Spec: v1alpha1.GitLabSourceSpec{
-					ProjectURL: "https://gitlab.com/project",
+					GroupURL: "https://gitlab.com/group",
 				},
 			},
-			ExpectedType: &projectWebhookClient{},
+			ExpectedType: &groupWebhookClient{},
 		},
 	}
 

--- a/pkg/client/gitlab/webook_client_test.go
+++ b/pkg/client/gitlab/webook_client_test.go
@@ -1,0 +1,59 @@
+package gitlab
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+	"knative.dev/eventing-gitlab/pkg/apis/sources/v1alpha1"
+)
+
+func TestWebhookClientGetterReturnsExpectedWebhookClient(t *testing.T) {
+	testCases := map[string]struct {
+		Spec         *v1alpha1.GitLabSource
+		ExpectedType interface{}
+	}{
+		"GitLab ProjectURL": {
+			Spec: &v1alpha1.GitLabSource{
+				Spec: v1alpha1.GitLabSourceSpec{
+					ProjectURL: "https://gitlab.com/project",
+				},
+			},
+			ExpectedType: &projectWebhookClient{},
+		},
+		"GitLab GroupURL": {
+			Spec: &v1alpha1.GitLabSource{
+				Spec: v1alpha1.GitLabSourceSpec{
+					ProjectURL: "https://gitlab.com/project",
+				},
+			},
+			ExpectedType: &projectWebhookClient{},
+		},
+	}
+
+	fakeclient := fake.NewSimpleClientset()
+
+	for tcName, tc := range testCases {
+		t.Run(tcName, func(t *testing.T) {
+			gitlabCg := NewWebhookClientGetter(fakeclient.CoreV1().Secrets)
+			gitlabCi, err := gitlabCg.Get(tc.Spec)
+
+			require.NoError(t, err)
+			require.IsType(t, tc.ExpectedType, gitlabCi)
+		})
+	}
+}
+
+func TestWebhookClientGetterReturnsErrorWithoutProjectOrGroupURL(t *testing.T) {
+	spec := &v1alpha1.GitLabSource{
+		Spec: v1alpha1.GitLabSourceSpec{},
+	}
+
+	fakeclient := fake.NewSimpleClientset()
+
+	gitlabCg := NewWebhookClientGetter(fakeclient.CoreV1().Secrets)
+	gitlabCi, err := gitlabCg.Get(spec)
+
+	require.Errorf(t, err, "reading the project or group url from the gitlab source spec: project or group url not found in gitlab source spec")
+	require.Nil(t, gitlabCi)
+}


### PR DESCRIPTION
Fixes #422

## Proposed Changes

- 🎁 Add support of gitlab groups as gitlab source

**Release Note**

```release-note
With this change it's also possible to use gitlab groups next to gitlab projects as event source using the `groupUrl`.

In the past it was only possible to use gitlab projects as event source using the `projectUrl`.

Backwards compatibility was an important requirement so if you only want to continue to use gitlab projects using the `projectUrl` you have to do nothing since there are no breaking changes.
```

---

Note: The `CustomResourceDefinition` will be updated asap