### PR TITLE
Pass application context to adapter setup

### DIFF
--- a/cmd/receive_adapter/main.go
+++ b/cmd/receive_adapter/main.go
@@ -20,8 +20,14 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 
 	gitlabadapter "knative.dev/eventing-gitlab/pkg/adapter"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/signals"
 )
 
 func main() {
-	adapter.Main("gitlabsource", gitlabadapter.NewEnvConfig, gitlabadapter.NewAdapter)
+	ctx := signals.NewContext()
+	cfg := injection.ParseAndGetRESTConfigOrDie()
+	ctx, _ = injection.Default.SetupInformers(ctx, cfg)
+
+	adapter.MainWithContext(ctx, "gitlabsource", gitlabadapter.NewEnvConfig, gitlabadapter.NewAdapter)
 }

--- a/cmd/receive_adapter/main.go
+++ b/cmd/receive_adapter/main.go
@@ -20,14 +20,12 @@ import (
 	"knative.dev/eventing/pkg/adapter/v2"
 
 	gitlabadapter "knative.dev/eventing-gitlab/pkg/adapter"
-	"knative.dev/pkg/injection"
 	"knative.dev/pkg/signals"
 )
 
 func main() {
 	ctx := signals.NewContext()
-	cfg := injection.ParseAndGetRESTConfigOrDie()
-	ctx, _ = injection.Default.SetupInformers(ctx, cfg)
+	ctx = adapter.WithInjectorEnabled(ctx)
 
 	adapter.MainWithContext(ctx, "gitlabsource", gitlabadapter.NewEnvConfig, gitlabadapter.NewAdapter)
 }


### PR DESCRIPTION
The adapter currently fails on startup due to:

```
Unable to fetch k8s.io/client-go/kubernetes.Interface from context. This context is not the application context (which is typically given to constructors via sharedmain).
```

https://cloud-native.slack.com/archives/C04LGHDR9K7/p1712893639063409

This is because, the "new" adapter requires a context with a kubeclient. This PR addresses it and passes a configured application context to adapter.MainWithContext()

Fixes #479